### PR TITLE
php8 fix Update class-posts-slide-renderer.php

### DIFF
--- a/public/class-posts-slide-renderer.php
+++ b/public/class-posts-slide-renderer.php
@@ -169,11 +169,13 @@ class BQW_SP_Posts_Slide_Renderer extends BQW_SP_Dynamic_Slide_Renderer {
 		if ( ! has_post_thumbnail( $post->ID ) ) {
 			return;
 		}
+		else { //olg20240808 php8 fix 
 
 		$image_size = $tag_arg !== false ? $tag_arg : 'full';
 		$image_src = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), $image_size );
 
 		return $image_src[0];
+		}
 	}
 
 	/**


### PR DESCRIPTION
i had a php8 deprecation notice on my dev site in the _render_image_src_  function, because of the missing else-block. this fixed it.